### PR TITLE
Fix BoundedDigits implementation so that it doesn't panic for MH country code

### DIFF
--- a/postalcodes.go
+++ b/postalcodes.go
@@ -234,8 +234,12 @@ func BoundedDigits(digits, low, high int) string {
 		low, high = high, low
 	}
 
-	max := (int(math.Pow10(digits)) - 1) & high
-	num := rand.Intn(max-low) + low
+	max := int(math.Pow10(digits)) - 1
+	if high > max {
+		high = max
+	}
+
+	num := rand.Intn(high-low) + low
 	format := fmt.Sprintf("%%0%dd", digits)
 	return fmt.Sprintf(format, num)
 }

--- a/postalcodes.go
+++ b/postalcodes.go
@@ -239,7 +239,7 @@ func BoundedDigits(digits, low, high int) string {
 		high = max
 	}
 
-	num := rand.Intn(high-low) + low
+	num := rand.Intn(high-low+1) + low
 	format := fmt.Sprintf("%%0%dd", digits)
 	return fmt.Sprintf(format, num)
 }

--- a/postalcodes_test.go
+++ b/postalcodes_test.go
@@ -37,6 +37,7 @@ var postalcodeTests = []struct {
 	{"PT", 8},
 	{"KR", 7},
 	{"TW", 5},
+	{"MH", 5},
 }
 
 func TestPostalCode(t *testing.T) {


### PR DESCRIPTION
It wasn't clear to me whether you intended BoundedDigits to be inclusive of the `high` argument. If not, I can remove the +1 from line 242.