### PR TITLE
Add a random IPv6 generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ func main() {
 	// Print a valid random IPv4 address
 	fmt.Println(randomdata.IpV4Address())
 
+	// Print a valid random IPv6 address
+	fmt.Println(randomdata.Ipv6Address())
+
 	// Print a day
 	fmt.Println(randomdata.Day())
   

--- a/random_data.go
+++ b/random_data.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -260,6 +261,16 @@ func IpV4Address() string {
 	}
 
 	return strings.Join(blocks, ".")
+}
+
+// Returns a valid IPv6 address as net.IP
+func IpV6Address() string {
+	var ip net.IP
+	for i := 0; i < net.IPv6len; i++ {
+		number := uint8(seedAndReturnRandom(255))
+		ip = append(ip, number)
+	}
+	return ip.String()
 }
 
 // Returns random day

--- a/random_data_example_test.go
+++ b/random_data_example_test.go
@@ -85,6 +85,9 @@ func ExampleRandomdata() {
 	// Print a random IPv4 address
 	fmt.Println(IpV4Address())
 
+	// Print a random IPv6 address
+	fmt.Println(IpV6Address())
+
 	// Print a random day
 	fmt.Println(Day())
 

--- a/random_data_test.go
+++ b/random_data_test.go
@@ -1,6 +1,8 @@
 package randomdata
 
 import (
+	"bytes"
+	"net"
 	"strconv"
 	"strings"
 	"testing"
@@ -232,6 +234,18 @@ func TestIpV4Address(t *testing.T) {
 		if blockNumber < 0 || blockNumber > 255 {
 			t.Error("Invalid generated IP address")
 		}
+	}
+}
+
+func TestIpV6Address(t *testing.T) {
+	ipAddress := net.ParseIP(IpV6Address())
+
+	if len(ipAddress) != net.IPv6len {
+		t.Errorf("Invalid generated IPv6 address %v", ipAddress)
+	}
+	roundTripIP := net.ParseIP(ipAddress.String())
+	if roundTripIP == nil || !bytes.Equal(ipAddress, roundTripIP) {
+		t.Errorf("Invalid generated IPv6 address %v", ipAddress)
 	}
 }
 


### PR DESCRIPTION
I noticed there is an IPv4 address generator, but no IPv6, so I added one.

Ipv4Address() generates the IP as a string, while I thought it made more sense to generate it as net.IP. Is it ok or should I change it to string too ?