### PR TITLE
Ignore testing related files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Testing specific
+*.out
+*.prof
+*.test


### PR DESCRIPTION
I was trying test coverage with following commands.

``` go
go test -coverprofile=coverage.out
go tool cover -html=coverage.out
```

which generates some testing related files, so added it to .gitignore in case some one else might try it.
See screen shot. 
![test-coverage](https://cloud.githubusercontent.com/assets/2920003/19102691/d91112f0-8aef-11e6-91a4-4a2f01f4d02d.png)
