### PR TITLE
Fix on GenerateProfile failing on unknown gender

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ func main() {
     // Get a complete and randomised profile of data generally used for users
     // There are many fields in the profile to use check the Profile struct definition in fullprofile.go
     profile := randomdata.GenerateProfile(randomdata.Male | randomdata.Female | randomdata.RandomGender)
-    fmt.Printf("The new profile's username is: %s and password (md5)", profile.Login.Username, profile.Login.Md5)
+    fmt.Printf("The new profile's username is: %s and password (md5): %s\n", profile.Login.Username, profile.Login.Md5)
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ func main() {
     fmt.Println(randomdata.IpV4Address())
 
     // Print a valid random IPv6 address
-    fmt.Println(randomdata.Ipv6Address())
+    fmt.Println(randomdata.IpV6Address())
 
     // Print a browser's user agent string
     fmt.Println(randomdata.UserAgentString())

--- a/fullprofile.go
+++ b/fullprofile.go
@@ -89,17 +89,17 @@ func getSha256(text string) string {
 func GenerateProfile(gender int) *Profile {
 	rand.Seed(time.Now().UnixNano())
 	profile := &Profile{}
-	if gender == RandomGender {
+	if gender == Male {
+		profile.Gender = "male"
+	} else if gender == Female {
+		profile.Gender = "female"
+	} else {
 		gender = rand.Intn(2)
 		if gender == Male {
 			profile.Gender = "male"
 		} else {
 			profile.Gender = "female"
 		}
-	} else if gender == Male {
-		profile.Gender = "male"
-	} else {
-		profile.Gender = "female"
 	}
 	profile.Name.Title = Title(gender)
 	profile.Name.First = FirstName(gender)


### PR DESCRIPTION
Hey, cool project!

I encountered some problems while running the example on the README. Here are some fixes I came up with.

1. Fix typo on README - Ipv6Address -> IpV6Address
2. We have this line on the example
```
profile := randomdata.GenerateProfile(randomdata.Male | randomdata.Female | randomdata.RandomGender)
```
which seems to be trying to do a bitwise OR. It might not be the case though, since I don't think the gender constants are `OR`-able.

Running that would produce:
```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/Pallinder/go-randomdata.GenerateProfile(0x3, 0x1)
	/home/jeff/go/src/github.com/Pallinder/go-randomdata/fullprofile.go:145 +0x1493
```

failing when indexing an unknown gender --- gender=3 on above.

As a failsafe, I decided it might be better if we consider unknown `gender` default to `RandomGender`.

Hope this helps.