### PR TITLE
Remove Canada/East-Saskatchewan

### DIFF
--- a/jsondata.go
+++ b/jsondata.go
@@ -2391,7 +2391,6 @@ var data = []byte(`{
         "Canada/Atlantic",
         "Canada/Central",
         "Canada/Eastern",
-        "Canada/East-Saskatchewan",
         "Canada/Mountain",
         "Canada/Newfoundland",
         "Canada/Pacific",


### PR DESCRIPTION
No longer a valid timezone in go 1.10