### PR TITLE
fullprofile fixes

### DIFF
--- a/fullprofile.go
+++ b/fullprofile.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -27,7 +26,7 @@ type Profile struct {
 		Street   string `json:"street"`
 		City     string `json:"city"`
 		State    string `json:"state"`
-		Postcode int    `json:"postcode"`
+		Postcode string `json:"postcode"`
 	} `json:"location"`
 
 	Email string `json:"email"`
@@ -119,8 +118,7 @@ func GenerateProfile(gender int) *Profile {
 	profile.Nat = "US"
 
 	profile.Location.City = City()
-	i, _ := strconv.Atoi(PostalCode("US"))
-	profile.Location.Postcode = i
+	profile.Location.Postcode = PostalCode("US")
 	profile.Location.State = State(Small)
 	profile.Location.Street = StringNumber(1, "") + " " + Street()
 

--- a/fullprofile.go
+++ b/fullprofile.go
@@ -121,7 +121,7 @@ func GenerateProfile(gender int) *Profile {
 	profile.Location.City = City()
 	i, _ := strconv.Atoi(PostalCode("US"))
 	profile.Location.Postcode = i
-	profile.Location.State = State(2)
+	profile.Location.State = State(Small)
 	profile.Location.Street = StringNumber(1, "") + " " + Street()
 
 	profile.Login.Username = SillyName()

--- a/fullprofile_test.go
+++ b/fullprofile_test.go
@@ -39,6 +39,10 @@ func Test_FullProfileGenerator(t *testing.T) {
 		t.Fatal("Profile Street failed to generate")
 	}
 
+	if len(profile.Location.State) != 2 {
+		t.Fatalf("Profile State code should be 2-character, but got %s\n", profile.Location.State)
+	}
+	
 	if profile.ID.Name != "SSN" {
 		t.Fatalf("Profile ID Name to be SSN, but got %s\n", profile.ID.Name)
 	}


### PR DESCRIPTION
Easy fixes: 
* fullprofile now creates two-letter state names. The code seems to have this intent already.
* fullprofile no longer coerces generated zips to ints. This fixes dropped leading '0' on east coast zips.