### PR TITLE
Fix #50 - FullDate() respect month days.

### DIFF
--- a/random_data.go
+++ b/random_data.go
@@ -326,7 +326,7 @@ func FullDate() string {
 	timestamp := time.Now()
 	year := timestamp.Year()
 	month := Number(1, 13)
-	maxDay := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, -1).Day()
+	maxDay := time.Date(year, time.Month(month+1), 0, 0, 0, 0, 0, time.UTC).Day()
 	day := Number(1, maxDay+1)
 	date := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
 	return date.Format(DateOutputLayout)

--- a/random_data.go
+++ b/random_data.go
@@ -324,11 +324,12 @@ func Month() string {
 // FullDate returns full date
 func FullDate() string {
 	timestamp := time.Now()
-	day := Day()
-	month := Month()
 	year := timestamp.Year()
-	fullDate := day + " " + strconv.Itoa(Number(1, 30)) + " " + month[0:3] + " " + strconv.Itoa(year)
-	return fullDate
+	month := Number(1, 13)
+	maxDay := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, -1).Day()
+	day := Number(1, maxDay+1)
+	date := time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.UTC)
+	return date.Format(DateOutputLayout)
 }
 
 // FullDateInRange returns a date string within a given range, given in the format "2006-01-02".

--- a/random_data_test.go
+++ b/random_data_test.go
@@ -340,11 +340,30 @@ func TestFullDate(t *testing.T) {
 	fulldateOne := FullDate()
 	fulldateTwo := FullDate()
 
-	if fulldateOne == fulldateTwo {
+	_, err := time.Parse(DateOutputLayout, fulldateOne)
+	if err != nil {
 		t.Error("Invalid random full date")
+	}
+
+	_, err = time.Parse(DateOutputLayout, fulldateTwo)
+	if err != nil {
+		t.Error("Invalid random full date")
+	}
+
+	if fulldateOne == fulldateTwo {
+		t.Error("Generated same full date twice in a row")
 	}
 }
 
+func TestFullDatePenetration(t *testing.T) {
+	for i := 0; i < 100000; i += 1 {
+		d := FullDate()
+		_, err := time.Parse(DateOutputLayout, d)
+		if err != nil {
+			t.Error("Invalid random full date")
+		}
+	}
+}
 func TestFullDateInRangeNoArgs(t *testing.T) {
 	t.Log("TestFullDateInRangeNoArgs")
 	fullDate := FullDateInRange()


### PR DESCRIPTION
### Background
The PR attempts to resolve bug [50](https://github.com/Pallinder/go-randomdata/issues/50). Generating dates will respect varying number of days in a month, e.g. February usually only has 28 days. This is accomplished by generating actual date objects instead of concatenating number strings.

### Changes
*MANDATORY*
- Fix `randomdata.FullDate()` method
- Add tests

### Checklist
- [x] Tests added
- [x] Documentation updated to include changes (if needed)
- [x] Gofmt run on your code
