### PR TITLE
Add semver information and CHANGELOG

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+Background
+*MANDATORY*
+Describe *WHY* this change is being made, be clear,
+use proper English and don't write lines longer than 80 chars.
+
+Caveats
+*OPTIONAL*
+Discuss any caveats your code may contain, remove if not needed.
+
+Changes
+*MANDATORY*
+- List your major changes one by one
+
+Checklist
+- [ ] Tests added
+- [ ] Documentation updated to include changes (if needed)
+- [ ] Gofmt run on your code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-### Changed
-- Update and improvement of Polish translation from [@m-aciek](https://github.com/m-aciek).
-
-## [1.0.0] - 2018-10-30a
+## [1.0.0] - 2018-10-30
 
 ### Added
 - This CHANGELOG file to hopefully serve as an evolving example of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Update and improvement of Polish translation from [@m-aciek](https://github.com/m-aciek).
+
+## [1.0.0] - 2018-10-30a
+
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- Enforcing Semver compatability in releases
+
+### Changed
+- Update README.md to include information about release strategy
+- Update README.md to link to CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ func main() {
 
 # Versioning / Release Strategy
 Go-Randomdata follows [Semver](https://www.semver.org)
-You can find current releases tagged under the releases section.
+
+You can find current releases tagged under the [releases section](https://github.com/Pallinder/go-randomdata/releases).
+
 The [CHANGELOG.md](CHANGELOG.md) file contains the changelog of the project.
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ func main() {
 
 ```
 
+# Versioning / Release Strategy
+Go-Randomdata follows [Semver](https://www.semver.org)
+You can find current releases tagged under the releases section.
+The [CHANGELOG.md](CHANGELOG.md) file contains the changelog of the project.
+
 ## Contributors
 
 * [jteeuwen](https://github.com/jteeuwen)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ func main() {
 
 ```
 
-# Versioning / Release Strategy
+## Versioning / Release Strategy
 Go-Randomdata follows [Semver](https://www.semver.org)
 
 You can find current releases tagged under the [releases section](https://github.com/Pallinder/go-randomdata/releases).


### PR DESCRIPTION
Background
To make sure people can better rely on us and to prepare
for the new golang package management system we need
to start to be more serious about versioning.
It was therefore decided to start relying on [Semver](https://www.semver.org).
This PR introduces an update to the README containing
information about how we deal with releases
and also introduces a CHANGELOG.md that can be used to keep track
of versions.

It was decided to start on V1.0 since this is used in production.

Discussions can be found in issue #48 

Changes
- Update README.md to include link to CHANGELOG.md
- Update README.md to include information about semver
- Add CHANGELOG.md for changelog related info