### PR TITLE
Allow space in the Postal Code for GB

### DIFF
--- a/postalcodes.go
+++ b/postalcodes.go
@@ -163,8 +163,11 @@ func PostalCode(countrycode string) string {
 	case "FK", "TC":
 		return Letters(4) + Digits(1) + Letters(2)
 
-	case "GG", "IM", "JE", "GB":
+	case "GG", "IM", "JE":
 		return Letters(2) + Digits(2) + Letters(2)
+
+	case "GB":
+		return Letters(2) + Digits(1) + " " + Digits(1) + Letters(2)
 
 	case "KY":
 		return Letters(2) + Digits(1) + "-" + Digits(4)

--- a/postalcodes_test.go
+++ b/postalcodes_test.go
@@ -1,6 +1,7 @@
 package randomdata
 
 import (
+	"regexp"
 	"testing"
 )
 
@@ -51,5 +52,26 @@ func TestPostalCode(t *testing.T) {
 
 		t.Fatalf("Invalid length for country %q: Expected %d, have %d.",
 			pt.Country, pt.Size, len(code))
+	}
+}
+
+func TestPostalCodeFormat(t *testing.T) {
+
+	for _, pt := range postalcodeTests {
+		code := PostalCode(pt.Country)
+
+		switch pt.Country {
+		case "GB":
+			matched, err := regexp.MatchString("^\\S{1,2}\\d{1,2} \\d\\S{1,2}", code)
+			if err != nil {
+				t.Errorf("error matching %v", err)
+			}
+
+			if !matched {
+				t.Fatalf("Invalid format for country %q",
+					pt.Country)
+			}
+
+		}
 	}
 }

--- a/postalcodes_test.go
+++ b/postalcodes_test.go
@@ -38,6 +38,7 @@ var postalcodeTests = []struct {
 	{"KR", 7},
 	{"TW", 5},
 	{"MH", 5},
+	{"GB", 7},
 }
 
 func TestPostalCode(t *testing.T) {


### PR DESCRIPTION
Background
*MANDATORY*
Just referring to the [Postcodes in the United Kingdom](https://en.wikipedia.org/wiki/Postcodes_in_the_United_Kingdom#Overview) Wikipedia article:
`Each post code is divided into two parts separated by a single space`.
So I have added a simple generation case.

Caveats
*OPTIONAL*
-none-

Changes
*MANDATORY*
extracted `GB` to a separate case, and added test checking the length to be 7 including space.

Checklist
- [x] Tests added
- [ ] Documentation updated to include changes (if needed) NOT NEEDED
- [x] Gofmt run on your code
