### PR TITLE
bugfix: privateRand is not safe for concurrent use

### DIFF
--- a/random_data.go
+++ b/random_data.go
@@ -98,7 +98,7 @@ func init() {
 }
 
 func CustomRand(randToUse *rand.Rand) {
-	privateRand = &pRand{randToUse, &sync.Mutex{}}
+	privateRand.pr = randToUse
 }
 
 // Returns a random part of a slice


### PR DESCRIPTION
Background
according to golang doc, rand.NewSource is not safe for concurrent use.
so I made this change. [see doc](https://golang.org/pkg/math/rand/#NewSource)

Changes
- use new struct instead of point of rand.Rand
- add mutex to lock unlock every map operation related to rand.Intn/rand.Int

Checklist
- [ ] Tests added
- [x] Documentation updated to include changes (if needed)
- [x] Gofmt run on your code
