### PR TITLE
Typo: "duchess" is spelled without a "t"

### DIFF
--- a/jsondata.go
+++ b/jsondata.go
@@ -670,7 +670,7 @@ var data = []byte(`{
         "prince",
         "princess",
         "duke",
-        "dutchess",
+        "duchess",
         "samurai",
         "ninja",
         "knave",


### PR DESCRIPTION
Background
*MANDATORY*
Describe *WHY* this change is being made, be clear,
use proper English and don't write lines longer than 80 chars.

_One of the words is mis-spelled—"duchess" should not have the letter "t"._

Changes
*MANDATORY*
- List your major changes one by one

_"duchess" is now spelled properly._

Checklist
- [x] Tests added
- [x] Documentation updated to include changes (if needed)
- [x] Gofmt run on your code
