### PR TITLE
remove 'slave' from nouns

### DIFF
--- a/jsondata.go
+++ b/jsondata.go
@@ -674,7 +674,6 @@ var data = []byte(`{
         "samurai",
         "ninja",
         "knave",
-        "slave",
         "servant",
         "sage",
         "wizard",


### PR DESCRIPTION
Background
This is being changed to remove the noun 'slave' from the list, it is unneeded.

Changes
Remove 'slave' from noun list
